### PR TITLE
Fix Jekyll config exclude entry

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,5 +14,5 @@ exclude:
   - Gemfile
   - Gemfile.lock
   - node_modules
-  - upload_post.py
+  - upload.py
   - README.md


### PR DESCRIPTION
## Summary
- ensure `upload.py` is ignored when the site builds

## Testing
- `python upload.py posts/oversharing.txt` *(fails: ModuleNotFoundError: No module named 'slugify')*

------
https://chatgpt.com/codex/tasks/task_e_688126050a888328ae80d07e17df1830